### PR TITLE
Failing version check from 1.10 onward

### DIFF
--- a/docker-pre-start.sh
+++ b/docker-pre-start.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname $0)/docker-functions.sh"
 
-GHOST_INSTALLED_VERSION=$(ghost version | grep '^Ghost Version' | grep -o '\d\.\d\.\d$')
+GHOST_INSTALLED_VERSION=$(ghost version | grep '^Ghost Version' | grep -o '\d\.\d*\.\d$')
 
 # If Ghost is not installed...
 if [ "$GHOST_INSTALLED_VERSION" == "" ]; then


### PR DESCRIPTION
Since Ghost minor versions entered into double digits, version check doesn't work anymore.

Accept more than one digit for minor version

```
/opt/ghost/home # ghost version | grep '^Ghost Version' | grep -o '\d\.\d*\.\d$'
1.14.0
```